### PR TITLE
Added Docker build file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:20-alpine
+
+RUN apk update
+RUN apk add git
+
+RUN git clone https://github.com/Stability-AI/StableStudio.git
+WORKDIR StableStudio
+
+RUN yarn
+
+ENTRYPOINT yarn dev --host


### PR DESCRIPTION
For those of us that want to avoid dependency problems, and use docker, here is a simple build file.

```
docker build -t stablestudio .
docker run -it --rm -p 3000:3000 --name stablestudio stablestudio

```

Suggest this gets added to the build process, and stored in GitHubs Docker repo.  Then no need for users to build it.
