### PR TITLE
webui plugin bug fix - check empty str

### DIFF
--- a/packages/stablestudio-plugin-webui/src/Utilities.ts
+++ b/packages/stablestudio-plugin-webui/src/Utilities.ts
@@ -41,7 +41,7 @@ export async function setOptions(baseUrl: string | undefined, options: any) {
 }
 
 export async function getImageInfo(
-  baseUrl: string | undefined,
+  baseUrl: string | null,
   base64image: any
 ) {
   const imageInfoResponse = await fetch(`${baseUrl}/sdapi/v1/png-info`, {

--- a/packages/stablestudio-plugin-webui/src/index.ts
+++ b/packages/stablestudio-plugin-webui/src/index.ts
@@ -94,7 +94,6 @@ export const createPlugin = StableStudio.createPlugin<{
     | "getStableDiffusionDefaultInput"
     | "getStableDiffusionExistingImages"
   > => {
-    webuiHostUrl = webuiHostUrl ?? "http://127.0.0.1:7861";
 
     return {
       createStableDiffusionImages: async (options) => {
@@ -244,8 +243,11 @@ export const createPlugin = StableStudio.createPlugin<{
     };
   };
 
-  const webuiHostUrl =
-    localStorage.getItem("webui-host-url") ?? "http://127.0.0.1:7861";
+  let webuiHostUrl = localStorage.getItem("webui-host-url");
+
+  if (!webuiHostUrl || webuiHostUrl === "") {
+    webuiHostUrl = "http://127.0.0.1:7861";
+  }
 
   return {
     ...webuiLoad(webuiHostUrl),


### PR DESCRIPTION
previously, we don't check empty str "", which leads to the empty host setting to be localhost:3000, not 127.0.0.1:3000 we expect and cause bug