### PR TITLE
Fixed links for Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 <img src="./misc/Banner.png" />
 <img src="./misc/GenerateScreenshot.png" style="width: 400px; max-width: 600px; flex-grow: 1;" />
 <img src="./misc/EditScreenshot.png" style="width: 400px; max-width: 600px; flex-grow: 1;" />
+</div>
 
+<center><span align="center" style="text-align: center; align-items: center;">
 <h3>👋 Welcome to StableStudio, the open-source version of <a href="https://dreamstudio.ai" target="_blank">DreamStudio</a>!</h3>
 
 **🗺 Contents – [🚀 Quick Start](#quick-start) · [ℹ️ About](#about) · [🙋 FAQ](#faq) · [🧑‍💻 Contributing](#contributing)**
@@ -12,10 +14,8 @@
 
 **🔗 Links – <a href="https://discord.com/channels/1002292111942635562/1108055793674227782" target="_blank">🎮 Discord</a> · <a href="https://dreamstudio.ai" target="_blank">🌈 DreamStudio</a> · <a href="https://github.com/Stability-AI/StableStudio/issues">🛟 Bugs & Support</a> · <a href="https://github.com/Stability-AI/StableStudio/discussions">💬 Discussion</a>**
 
-<br />
-<br />
-
-</div>
+</span></center>
+<br /><br />
 
 # <a id="quick-start" href="#quick-start">🚀 Quick Start</a>
 


### PR DESCRIPTION
Moved top links out of div tag so they work with Markdown showdown.min.js to display readme text in html embeds. Added center tag around span tag to retain centering with Markdown. (Span tags are stripped out by Markdown and content of div tags is ignored by Markdown.)