### PR TITLE
Plugin resolution support

### DIFF
--- a/packages/stablestudio-plugin/src/Plugin.ts
+++ b/packages/stablestudio-plugin/src/Plugin.ts
@@ -194,7 +194,7 @@ export type Plugin<P extends PluginTypeHelper = PluginTypeHelperDefault> = {
   /** If you want to provide a list of resolutions in pixels to choose from, you can return them via this function and they will be presented as a slider in the UI */
   getStableDiffusionAllowedResolutions?: (
     model?: ID
-  ) => { width: number; height: number }[] | undefined;
+  ) => MaybePromise<{ width: number; height: number }[] | undefined>;
 
   /** Determines the default count passed to `createStableDiffusionImages` */
   getStableDiffusionDefaultCount?: () => number | undefined;

--- a/packages/stablestudio-plugin/src/Plugin.ts
+++ b/packages/stablestudio-plugin/src/Plugin.ts
@@ -191,6 +191,11 @@ export type Plugin<P extends PluginTypeHelper = PluginTypeHelperDefault> = {
     StableDiffusionStyle[] | undefined
   >;
 
+  /** If you want to provide a list of resolutions in pixels to choose from, you can return them via this function and they will be presented as a dropdown in the UI */
+  getStableDiffusionAllowedResolutions?: (
+    model?: ID
+  ) => { width: number; height: number }[] | undefined;
+
   /** Determines the default count passed to `createStableDiffusionImages` */
   getStableDiffusionDefaultCount?: () => number | undefined;
 

--- a/packages/stablestudio-plugin/src/Plugin.ts
+++ b/packages/stablestudio-plugin/src/Plugin.ts
@@ -191,7 +191,7 @@ export type Plugin<P extends PluginTypeHelper = PluginTypeHelperDefault> = {
     StableDiffusionStyle[] | undefined
   >;
 
-  /** If you want to provide a list of resolutions in pixels to choose from, you can return them via this function and they will be presented as a dropdown in the UI */
+  /** If you want to provide a list of resolutions in pixels to choose from, you can return them via this function and they will be presented as a slider in the UI */
   getStableDiffusionAllowedResolutions?: (
     model?: ID
   ) => { width: number; height: number }[] | undefined;


### PR DESCRIPTION
Adds support for `getStableDiffusionAllowedResolutions` in plugins. Return an array of resolutions to override the resolutions presented in the slider.